### PR TITLE
write example in one row example table

### DIFF
--- a/src/TestStack.BDDfy.Xunit/BatchBddfyConsoleReporter.cs
+++ b/src/TestStack.BDDfy.Xunit/BatchBddfyConsoleReporter.cs
@@ -142,6 +142,8 @@ namespace TestStack.BDDfy.Xunit
 					}
 
 					var exampleScenario = scenarioGroup.First(); // Fixed bug here: original iterates story.Scenarios instead of scenarioGroup
+					WriteLine();
+					WriteExamples(exampleScenario, scenarioGroup);
 					ReportTags(exampleScenario.Tags);
 				}
 			}

--- a/src/TestStack.BDDfy.Xunit/ThreadsafeBddfyTextReporter.cs
+++ b/src/TestStack.BDDfy.Xunit/ThreadsafeBddfyTextReporter.cs
@@ -61,6 +61,8 @@ namespace TestStack.BDDfy.Xunit
 					}
 
 					var exampleScenario = scenarioGroup.First();
+					WriteLine();
+					WriteExamples(exampleScenario, scenarioGroup);
 					ReportTags(exampleScenario.Tags);
 				}
 			}


### PR DESCRIPTION
When the example table has one row, the processor doesn't show the row.