### PR TITLE
Bugfix/test output helper multiple tests

### DIFF
--- a/TestStack.BDDfy.Xunit.sln
+++ b/TestStack.BDDfy.Xunit.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.12.35323.107
+# Visual Studio 15
+VisualStudioVersion = 15.0.26228.12
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{BCBEE5D8-A791-412F-8525-BDDDD3BA22B7}"
 EndProject

--- a/TestStack.BDDfy.Xunit.sln
+++ b/TestStack.BDDfy.Xunit.sln
@@ -1,4 +1,4 @@
-﻿﻿
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26228.12
@@ -32,8 +32,5 @@ Global
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{7FB2B61B-79BB-482E-9BDE-93A4B3DB9D1C} = {BCBEE5D8-A791-412F-8525-BDDDD3BA22B7}
-	EndGlobalSection
-	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {0243AC46-6E20-4AFA-8A0C-F6E53C67E407}
 	EndGlobalSection
 EndGlobal

--- a/TestStack.BDDfy.Xunit.sln
+++ b/TestStack.BDDfy.Xunit.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26228.12
+# Visual Studio Version 17
+VisualStudioVersion = 17.12.35323.107
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{BCBEE5D8-A791-412F-8525-BDDDD3BA22B7}"
 EndProject
@@ -32,5 +32,8 @@ Global
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{7FB2B61B-79BB-482E-9BDE-93A4B3DB9D1C} = {BCBEE5D8-A791-412F-8525-BDDDD3BA22B7}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {0243AC46-6E20-4AFA-8A0C-F6E53C67E407}
 	EndGlobalSection
 EndGlobal

--- a/TestStack.BDDfy.Xunit.sln
+++ b/TestStack.BDDfy.Xunit.sln
@@ -1,4 +1,4 @@
-﻿
+﻿﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26228.12

--- a/src/TestStack.BDDfy.Xunit/BddfyXunitTestRunner.cs
+++ b/src/TestStack.BDDfy.Xunit/BddfyXunitTestRunner.cs
@@ -27,12 +27,20 @@ namespace TestStack.BDDfy.Xunit
 			BddfyInitializer.EnsureInitialized();
 			TestOutputHelper testOutputHelper = null;
 			for (var idx = 0; idx < ConstructorArguments.Length; ++idx)
+			{
 				if (ConstructorArguments[idx] is Func<TestOutputHelper>)
 				{
 					testOutputHelper = new TestOutputHelper();
 					ConstructorArguments[idx] = testOutputHelper;
 					break;
 				}
+
+				if (ConstructorArguments[idx] is TestOutputHelper existingOutputHelper)
+				{
+					testOutputHelper = existingOutputHelper;
+					break;
+				}
+			}
 
 			if (testOutputHelper == null)
 				testOutputHelper = new TestOutputHelper();
@@ -44,7 +52,6 @@ namespace TestStack.BDDfy.Xunit
 
 			var output = testOutputHelper.Output;
 			testOutputHelper.Uninitialize();
-
 			return Tuple.Create(executionTime, output);
 		}
 	}


### PR DESCRIPTION
Fixes this issue https://github.com/shaynevanasperen/TestStack.BDDfy.Xunit/issues/9

Given that I have a test class in which ITestOutputHelper is injected to write custom outputs.
And the the test class has multple tests
When I run all the tests
Then only first one works and logs to ouput logger
And rest of them fail with error message "There is no currently active test."

When I checked hashcode of the output helper, it was same for both the tests. When i tested same without "Fact" attribute instead of "BddfyFact" attribute then the output helper is different both times. I believe that this library is retaining and injecting the same output helper both times but because the test context is destroyed after the first test, the second one fails.